### PR TITLE
Change case syntax to work on Puppet 4.x

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,7 +4,7 @@ class zabbixagent::install (
   $custom_require_linux   = $::zabbixagent::custom_require_linux,
   $custom_require_windows = $::zabbixagent::custom_require_windows) {
   case $::kernel {
-    Linux   : {
+    'Linux'   : {
       package { 'zabbix-agent':
         ensure  => $ensure_setting,
         notify  => Service['zabbix-agent'],
@@ -12,7 +12,7 @@ class zabbixagent::install (
       }
     } # end Linux
 
-    Windows : {
+    'Windows' : {
       package { 'zabbix-agent':
         ensure   => $ensure_setting,
         provider => 'chocolatey',

--- a/manifests/preinstall.pp
+++ b/manifests/preinstall.pp
@@ -3,7 +3,7 @@ class zabbixagent::preinstall (
   $manage_repo_epel   = $::zabbixagent::manage_repo_epel,
   $manage_repo_zabbix = $::zabbixagent::manage_repo_zabbix,) {
   case $::osfamily {
-    RedHat  : {
+    'RedHat'  : {
       # EPEL
       if ($manage_repo_epel) {
         file { '/etc/yum.repos.d/epel.repo':
@@ -38,9 +38,9 @@ class zabbixagent::preinstall (
 
     } # end RedHat
 
-    Debian  : {
+    'Debian'  : {
       case $::operatingsystem {
-        Ubuntu  : {
+        'Ubuntu'  : {
           # Zabbix
           if ($manage_repo_zabbix) {
             file { '/etc/apt/sources.list.d/zabbix.list':


### PR DESCRIPTION
Changed case syntax according official puppet style guide (https://docs.puppetlabs.com/puppet/latest/reference/lang_conditional.html#case-statements).

This change ensures Puppet code will work on Puppet 3.x and 4.x versions.