### PR TITLE
Zabbix Agent 3.4 Support

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -56,7 +56,7 @@ zabbixagent::tls_server_cert_subject:
 zabbixagent::unsafe_user_parameters:
 zabbixagent::user_parameter:
 zabbixagent::user:
-zabbixagent::version: '3.2'
+zabbixagent::version: '3.4'
 zabbixagent::config_dir: fail($fail_message)
 zabbixagent::log_file: fail($fail_message)
 zabbixagent::fail_message: "${::kernel} is not yet supported by this module."

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -335,7 +335,7 @@ class zabbixagent (
     fail('$servers_active must be either a string or an array')
   }
 
-  if !($version in [ '2.4', '3.0', '3.2' ]) {
+  if !($version in [ '2.4', '3.0', '3.2', '3.4' ]) {
     fail("Zabbix ${version} is not supported but PR's are welcome.")
   }
 

--- a/spec/classes/zabbixagent_install_spec.rb
+++ b/spec/classes/zabbixagent_install_spec.rb
@@ -13,7 +13,7 @@ describe 'zabbixagent::install' do
           let :pre_condition do
             "class {'zabbixagent':
               manage_repo_zabbix => true,
-              version            => '3.2',
+              version            => '3.4',
             }"
           end
 
@@ -23,7 +23,7 @@ describe 'zabbixagent::install' do
           let :pre_condition do
             "class {'zabbixagent':
               manage_repo_zabbix => false,
-              version            => '3.2',
+              version            => '3.4',
             }"
           end
 

--- a/spec/classes/zabbixagent_preinstall_spec.rb
+++ b/spec/classes/zabbixagent_preinstall_spec.rb
@@ -11,7 +11,7 @@ describe 'zabbixagent::preinstall' do
         "class {'zabbixagent':
           manage_repo_zabbix => true,
           manage_repo_epel   => true,
-          version            => '3.2',
+          version            => '3.4',
         }"
       end
       case facts[:os]['family']
@@ -32,18 +32,18 @@ describe 'zabbixagent::preinstall' do
         case facts[:os]['release']['major']
         when '5'
           it 'should create zabbix.repo' do
-            is_expected.to contain_file('/etc/yum.repos.d/zabbix.repo').with_content(/baseurl=http:\/\/repo.zabbix.com\/zabbix\/3.2\/rhel\/#{facts[:os]['release']['major']}\/\$basearch\//)
+            is_expected.to contain_file('/etc/yum.repos.d/zabbix.repo').with_content(/baseurl=http:\/\/repo.zabbix.com\/zabbix\/3.4\/rhel\/#{facts[:os]['release']['major']}\/\$basearch\//)
             is_expected.to contain_file('/etc/yum.repos.d/zabbix.repo').with_content(/gpgkey=http:\/\/repo.zabbix.com\/RPM-GPG-KEY-ZABBIX-A14FE591-EL5/)
           end
         else
           it 'should create zabbix.repo' do
-            is_expected.to contain_file('/etc/yum.repos.d/zabbix.repo').with_content(/baseurl=http:\/\/repo.zabbix.com\/zabbix\/3.2\/rhel\/#{facts[:os]['release']['major']}\/\$basearch\//)
+            is_expected.to contain_file('/etc/yum.repos.d/zabbix.repo').with_content(/baseurl=http:\/\/repo.zabbix.com\/zabbix\/3.4\/rhel\/#{facts[:os]['release']['major']}\/\$basearch\//)
             is_expected.to contain_file('/etc/yum.repos.d/zabbix.repo').with_content(/gpgkey=http:\/\/repo.zabbix.com\/RPM-GPG-KEY-ZABBIX-A14FE591/)
           end
         end # ends case facts[:operatingsystemmajrelease]
       when 'Debian'
         it 'should create zabbix.list' do
-          is_expected.to contain_file('/etc/apt/sources.list.d/zabbix.list').with_content(/deb http:\/\/repo.zabbix.com\/zabbix\/3.2\/#{facts[:os]['name'].downcase} #{facts[:os]['lsb']['distcodename']} main/)
+          is_expected.to contain_file('/etc/apt/sources.list.d/zabbix.list').with_content(/deb http:\/\/repo.zabbix.com\/zabbix\/3.4\/#{facts[:os]['name'].downcase} #{facts[:os]['lsb']['distcodename']} main/)
         end
 
         it { is_expected.to contain_exec('apt-get update') }

--- a/templates/zabbix.repo.epp
+++ b/templates/zabbix.repo.epp
@@ -21,7 +21,7 @@ gpgcheck=1
 gpgkey=http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX
 <% } elsif $zabbixagent::version == '3.0' { -%>
 gpgkey=http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-79EA5ED4
-<% } elsif $zabbixagent::version == '3.2' { -%>
+<% } elsif $zabbixagent::version =~ /^3\.2|4/ { -%>
 <% if $facts['os']['release']['major'] == '5' { -%>
 gpgkey=http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-A14FE591-EL5
 <% } else { -%>
@@ -38,7 +38,7 @@ gpgcheck=1
 gpgkey=http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX
 <% } elsif $zabbixagent::version == '3.0' { -%>
 gpgkey=http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-79EA5ED4
-<% } elsif $zabbixagent::version == '3.2' { -%>
+<% } elsif $zabbixagent::version =~ /^3\.2|4/  { -%>
 <% if $facts['os']['release']['major'] == '5' { -%>
 gpgkey=http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-A14FE591-EL5
 <% } else { -%>


### PR DESCRIPTION
Addressed issue #10 by adding support for Zabbix agent 3.4. Still need to remove EOL operating systems and compare agent config files from 3.2 vs 3.4.